### PR TITLE
Use evaluate for Scrolls metrics

### DIFF
--- a/lm_eval/tasks/scrolls/task.py
+++ b/lm_eval/tasks/scrolls/task.py
@@ -3,7 +3,7 @@ import numpy as np
 import transformers.data.metrics.squad_metrics as squad_metrics
 
 from abc import abstractmethod
-from datasets import load_metric
+import evaluate
 from transformers import AutoTokenizer
 from functools import reduce
 
@@ -116,7 +116,7 @@ class _SCROLLSTask(Task):
     PRUNE_NUM_PROC = None
 
     def __post_init__(self):
-        self.metric = load_metric(_download_metric(), config_name=self.DATASET_NAME)
+        self.metric = evaluate.load(_download_metric(), config_name=self.DATASET_NAME)
 
     def has_training_docs(self):
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ tqdm
 
 deepspeed
 datasets
+evaluate
 tensorboardX
 peft

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ requirements = [
     "typing_extensions>=4.8.0",
     "accelerate",
     "datasets",
+    "evaluate",
     "zstandard",
 ]
 


### PR DESCRIPTION
## Summary
- replace deprecated `datasets.load_metric` with `evaluate.load` for SCROLLS tasks
- add `evaluate` to project dependencies

## Testing
- `pip install evaluate` *(fails: Could not find a version that satisfies the requirement evaluate)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'awq_ext')*

------
https://chatgpt.com/codex/tasks/task_e_689be44e7de483328c0c0b3299cf49d9