### PR TITLE
Add NVFP4 quantizer support and qzeros handling

### DIFF
--- a/auto_gptq/modeling/_utils.py
+++ b/auto_gptq/modeling/_utils.py
@@ -399,6 +399,9 @@ def pack_model(
     for name in qlayers:
         logger.info(f'{name} | starting packing')
         quantizers[name], scale, zero, g_idx = quantizers[name]
+        # propagate quantization type information to the layer
+        qlayers[name].quant_type = getattr(quantizers[name], "quant_type", "")
+
         # so far can only pack layer on CPU
         layer_device = qlayers[name].device
         qlayers[name].to(CPU)

--- a/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_cuda.py
@@ -166,41 +166,53 @@ class QuantLinear(nn.Module):
         qweight = qweight.astype(np.int32)
         self.qweight = torch.from_numpy(qweight)
 
-        zeros -= 1
-        zeros = zeros.numpy().astype(np.uint32)
-        qzeros = np.zeros((zeros.shape[0], zeros.shape[1] // 32 * self.bits), dtype=np.uint32)
-        i = 0
-        col = 0
-        while col < qzeros.shape[1]:
-            if self.bits in [2, 4, 8]:
-                for j in range(i, i + (32 // self.bits)):
-                    qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
-                i += 32 // self.bits
-                col += 1
-            elif self.bits == 3:
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i))
-                i += 10
-                qzeros[:, col] |= zeros[:, i] << 30
-                col += 1
-                qzeros[:, col] |= (zeros[:, i] >> 2) & 1
-                i += 1
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 1)
-                i += 10
-                qzeros[:, col] |= zeros[:, i] << 31
-                col += 1
-                qzeros[:, col] |= (zeros[:, i] >> 1) & 0x3
-                i += 1
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 2)
-                i += 10
-                col += 1
-            else:
-                raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+        if getattr(self, "quant_type", "") == "nvfp4":
+            self.qzeros = torch.zeros(
+                (
+                    math.ceil(self.infeatures / self.group_size),
+                    self.outfeatures // 32 * self.bits,
+                ),
+                dtype=torch.int32,
+            )
+        else:
+            zeros -= 1
+            zeros = zeros.numpy().astype(np.uint32)
+            qzeros = np.zeros(
+                (zeros.shape[0], zeros.shape[1] // 32 * self.bits),
+                dtype=np.uint32,
+            )
+            i = 0
+            col = 0
+            while col < qzeros.shape[1]:
+                if self.bits in [2, 4, 8]:
+                    for j in range(i, i + (32 // self.bits)):
+                        qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
+                    i += 32 // self.bits
+                    col += 1
+                elif self.bits == 3:
+                    for j in range(i, i + 10):
+                        qzeros[:, col] |= zeros[:, j] << (3 * (j - i))
+                    i += 10
+                    qzeros[:, col] |= zeros[:, i] << 30
+                    col += 1
+                    qzeros[:, col] |= (zeros[:, i] >> 2) & 1
+                    i += 1
+                    for j in range(i, i + 10):
+                        qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 1)
+                    i += 10
+                    qzeros[:, col] |= zeros[:, i] << 31
+                    col += 1
+                    qzeros[:, col] |= (zeros[:, i] >> 1) & 0x3
+                    i += 1
+                    for j in range(i, i + 10):
+                        qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 2)
+                    i += 10
+                    col += 1
+                else:
+                    raise NotImplementedError("Only 2,3,4,8 bits are supported.")
 
-        qzeros = qzeros.astype(np.int32)
-        self.qzeros = torch.from_numpy(qzeros)
+            qzeros = qzeros.astype(np.int32)
+            self.qzeros = torch.from_numpy(qzeros)
 
     def forward(self, x: torch.Tensor):
         out_shape = x.shape[:-1] + (self.outfeatures,)

--- a/auto_gptq/nn_modules/qlinear/qlinear_cuda_old.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_cuda_old.py
@@ -163,41 +163,53 @@ class QuantLinear(nn.Module):
         qweight = qweight.astype(np.int32)
         self.qweight = torch.from_numpy(qweight)
 
-        zeros -= 1
-        zeros = zeros.numpy().astype(np.uint32)
-        qzeros = np.zeros((zeros.shape[0], zeros.shape[1] // 32 * self.bits), dtype=np.uint32)
-        i = 0
-        col = 0
-        while col < qzeros.shape[1]:
-            if self.bits in [2, 4, 8]:
-                for j in range(i, i + (32 // self.bits)):
-                    qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
-                i += 32 // self.bits
-                col += 1
-            elif self.bits == 3:
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i))
-                i += 10
-                qzeros[:, col] |= zeros[:, i] << 30
-                col += 1
-                qzeros[:, col] |= (zeros[:, i] >> 2) & 1
-                i += 1
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 1)
-                i += 10
-                qzeros[:, col] |= zeros[:, i] << 31
-                col += 1
-                qzeros[:, col] |= (zeros[:, i] >> 1) & 0x3
-                i += 1
-                for j in range(i, i + 10):
-                    qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 2)
-                i += 10
-                col += 1
-            else:
-                raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+        if getattr(self, "quant_type", "") == "nvfp4":
+            self.qzeros = torch.zeros(
+                (
+                    math.ceil(self.infeatures / self.group_size),
+                    self.outfeatures // 32 * self.bits,
+                ),
+                dtype=torch.int32,
+            )
+        else:
+            zeros -= 1
+            zeros = zeros.numpy().astype(np.uint32)
+            qzeros = np.zeros(
+                (zeros.shape[0], zeros.shape[1] // 32 * self.bits),
+                dtype=np.uint32,
+            )
+            i = 0
+            col = 0
+            while col < qzeros.shape[1]:
+                if self.bits in [2, 4, 8]:
+                    for j in range(i, i + (32 // self.bits)):
+                        qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
+                    i += 32 // self.bits
+                    col += 1
+                elif self.bits == 3:
+                    for j in range(i, i + 10):
+                        qzeros[:, col] |= zeros[:, j] << (3 * (j - i))
+                    i += 10
+                    qzeros[:, col] |= zeros[:, i] << 30
+                    col += 1
+                    qzeros[:, col] |= (zeros[:, i] >> 2) & 1
+                    i += 1
+                    for j in range(i, i + 10):
+                        qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 1)
+                    i += 10
+                    qzeros[:, col] |= zeros[:, i] << 31
+                    col += 1
+                    qzeros[:, col] |= (zeros[:, i] >> 1) & 0x3
+                    i += 1
+                    for j in range(i, i + 10):
+                        qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 2)
+                    i += 10
+                    col += 1
+                else:
+                    raise NotImplementedError("Only 2,3,4,8 bits are supported.")
 
-        qzeros = qzeros.astype(np.int32)
-        self.qzeros = torch.from_numpy(qzeros)
+            qzeros = qzeros.astype(np.int32)
+            self.qzeros = torch.from_numpy(qzeros)
 
     def forward(self, x):
         x_dtype = x.dtype

--- a/auto_gptq/nn_modules/qlinear/qlinear_triton.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_triton.py
@@ -132,22 +132,34 @@ class QuantLinear(nn.Module, TritonModuleMixin):
         qweight = qweight.astype(np.int32)
         self.qweight = torch.from_numpy(qweight)
 
-        zeros -= 1
-        zeros = zeros.numpy().astype(np.uint32)
-        qzeros = np.zeros((zeros.shape[0], zeros.shape[1] // 32 * self.bits), dtype=np.uint32)
-        i = 0
-        col = 0
-        while col < qzeros.shape[1]:
-            if self.bits in [2, 4, 8]:
-                for j in range(i, i + (32 // self.bits)):
-                    qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
-                i += 32 // self.bits
-                col += 1
-            else:
-                raise NotImplementedError("Only 2,4,8 bits are supported.")
+        if getattr(self, "quant_type", "") == "nvfp4":
+            self.qzeros = torch.zeros(
+                (
+                    math.ceil(self.infeatures / self.group_size),
+                    self.outfeatures // 32 * self.bits,
+                ),
+                dtype=torch.int32,
+            )
+        else:
+            zeros -= 1
+            zeros = zeros.numpy().astype(np.uint32)
+            qzeros = np.zeros(
+                (zeros.shape[0], zeros.shape[1] // 32 * self.bits),
+                dtype=np.uint32,
+            )
+            i = 0
+            col = 0
+            while col < qzeros.shape[1]:
+                if self.bits in [2, 4, 8]:
+                    for j in range(i, i + (32 // self.bits)):
+                        qzeros[:, col] |= zeros[:, j] << (self.bits * (j - i))
+                    i += 32 // self.bits
+                    col += 1
+                else:
+                    raise NotImplementedError("Only 2,4,8 bits are supported.")
 
-        qzeros = qzeros.astype(np.int32)
-        self.qzeros = torch.from_numpy(qzeros)
+            qzeros = qzeros.astype(np.int32)
+            self.qzeros = torch.from_numpy(qzeros)
 
     def forward(self, x):
         out_shape = x.shape[:-1] + (self.outfeatures,)

--- a/auto_gptq/quantization/nvfp4.py
+++ b/auto_gptq/quantization/nvfp4.py
@@ -1,0 +1,24 @@
+import torch
+from .quantizer import Quantizer
+
+
+class NVFP4Quantizer(Quantizer):
+    """Quantizer placeholder for NVFP4 weights.
+
+    The NVFP4 format already represents values in a floating point format
+    with an implicit scale of ``1`` and zero point ``0``.  As a result the
+    quantization parameters for weights are trivial and can be populated
+    without inspecting the tensor statistics.
+    """
+
+    quant_type = "nvfp4"
+
+    def find_params(self, x, weight: bool = False):
+        if weight:
+            # NVFP4 weights use a fixed scale of 1 and a zero point of 0
+            self.scale = torch.ones((x.shape[0], 1), device=x.device)
+            self.zero = torch.zeros((x.shape[0], 1), device=x.device)
+            return
+        # Fallback to default behaviour for non-weight tensors
+        super().find_params(x, weight=weight)
+


### PR DESCRIPTION
## Summary
- add NVFP4Quantizer with fixed scale and zero for weights
- skip zero offset and pack zeros correctly when quant_type is nvfp4
- propagate quantization type during model packing

## Testing
- `pytest -q` *(fails: No module named 'awq_ext')*
- `python quantize_gptq_olmoe.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bea7bca708332b71edcaf1725b079