### PR TITLE
feat: export GPTQ weights for OLMoE

### DIFF
--- a/auto_gptq/modeling/__init__.py
+++ b/auto_gptq/modeling/__init__.py
@@ -23,3 +23,4 @@ from .stablelmepoch import StableLMEpochGPTQForCausalLM
 from .xverse import XverseGPTQForCausalLM
 from .yi import YiGPTQForCausalLM
 from .deepseek import DeepSeekGPTQForCausalLM
+from .olmoe import OlmoeGPTQForCausalLM

--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -47,7 +47,7 @@ from ._utils import (
 )
 from ..nn_modules._fused_base import FusedBaseAttentionModule, FusedBaseMLPModule
 from ..nn_modules.qlinear import GeneralQuantLinear
-from ..quantization import GPTQ
+from ..quantization import GPTQ, Quantizer, NVFP4Quantizer
 from ..utils.data_utils import collate_data
 from ..utils.import_utils import (
     AUTOGPTQ_CUDA_AVAILABLE,
@@ -184,6 +184,7 @@ class BaseQuantizeConfig(PushToHubMixin):
     def to_dict(self):
         return {
             "bits": self.bits,
+            "quant_type": self.quant_type,
             "group_size": self.group_size,
             "damp_percent": self.damp_percent,
             "desc_act": self.desc_act,
@@ -200,6 +201,7 @@ class BaseQuantizeConfig(PushToHubMixin):
 @dataclass
 class BaseQuantizeConfig_mixed_precision(PushToHubMixin):
     bits: dict
+    quant_type: str = field(default="int")
     group_size: int = field(default=-1)
     damp_percent: float = field(default=0.01)
     desc_act: bool = field(default=True)
@@ -304,6 +306,7 @@ class BaseQuantizeConfig_mixed_precision(PushToHubMixin):
     def to_dict(self):
         return {
             "bits": self.bits,
+            "quant_type": self.quant_type,
             "group_size": self.group_size,
             "damp_percent": self.damp_percent,
             "desc_act": self.desc_act,
@@ -539,8 +542,11 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
             for names in inside_layer_modules:
                 subset = {n: full[n] for n in names if n in full}
                 gptq = {}
+                quantizer_cls = (
+                    NVFP4Quantizer if self.quantize_config.quant_type == "nvfp4" else Quantizer
+                )
                 for name in subset:
-                    gptq[name] = GPTQ(subset[name])
+                    gptq[name] = GPTQ(subset[name], quantizer=quantizer_cls())
                     gptq[name].quantizer.configure(
                         self.quantize_config.bits,
                         perchannel=True,
@@ -1774,11 +1780,12 @@ class BaseGPTQForCausalLM_mixed_precision(nn.Module, PushToHubMixin):
             for names in inside_layer_modules:
                 subset = {n: full[n] for n in names if n in full}
                 gptq = {}
+                quantizer_cls = (
+                    NVFP4Quantizer if self.quantize_config.quant_type == "nvfp4" else Quantizer
+                )
                 for name in subset:
-                    # print(f'{self.layers_block_name}.{i}.{name}')
-                    # print(self.quantize_config.bits)
                     layer_bits = self.quantize_config.bits[f'{self.layers_block_name}.{i}.{name}']
-                    gptq[name] = GPTQ(subset[name])
+                    gptq[name] = GPTQ(subset[name], quantizer=quantizer_cls())
                     gptq[name].quantizer.configure(
                         layer_bits,
                         perchannel=True,

--- a/auto_gptq/modeling/_const.py
+++ b/auto_gptq/modeling/_const.py
@@ -23,7 +23,8 @@ SUPPORTED_MODELS = [
     "xverse",
     "deci",
     "stablelm_epoch",
-    "deepseek"
+    "deepseek",
+    "olmoe",
 ]
 if compare_transformers_version("v4.28.0", op="ge"):
     SUPPORTED_MODELS.append("llama")

--- a/auto_gptq/modeling/auto.py
+++ b/auto_gptq/modeling/auto.py
@@ -26,6 +26,7 @@ from .stablelmepoch import StableLMEpochGPTQForCausalLM
 from .xverse import XverseGPTQForCausalLM
 from .yi import YiGPTQForCausalLM
 from .deepseek import DeepSeekGPTQForCausalLM
+from .olmoe import OlmoeGPTQForCausalLM
 
 GPTQ_CAUSAL_LM_MODEL_MAP = {
     "bloom": BloomGPTQForCausalLM,
@@ -53,6 +54,7 @@ GPTQ_CAUSAL_LM_MODEL_MAP = {
     "longllama": LongLlamaGPTQForCausalLM,
     "gemma": GemmaGPTQForCausalLM,
     "deepseek": DeepSeekGPTQForCausalLM,
+    "olmoe": OlmoeGPTQForCausalLM,
 }
 
 

--- a/auto_gptq/modeling/olmoe.py
+++ b/auto_gptq/modeling/olmoe.py
@@ -1,0 +1,29 @@
+from ._base import BaseGPTQForCausalLM_mixed_precision
+
+
+class OlmoeGPTQForCausalLM(BaseGPTQForCausalLM_mixed_precision):
+    """GPTQ wrapper for OLMoE models."""
+
+    model_type = "olmoe"
+    layer_type = "OlmoeDecoderLayer"
+    layers_block_name = "model.layers"
+    outside_layer_modules = ["model.embed_tokens", "model.norm"]
+
+    moe_w13_list = []
+    for i in range(8):
+        moe_w13_list.append(f"block_sparse_moe.experts.{i}.w1")
+        moe_w13_list.append(f"block_sparse_moe.experts.{i}.w3")
+
+    moe_w2_list = []
+    for i in range(8):
+        moe_w2_list.append(f"block_sparse_moe.experts.{i}.w2")
+
+    inside_layer_modules = [
+        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        ["self_attn.o_proj"],
+        moe_w13_list,
+        moe_w2_list,
+    ]
+
+
+__all__ = ["OlmoeGPTQForCausalLM"]

--- a/auto_gptq/quantization/__init__.py
+++ b/auto_gptq/quantization/__init__.py
@@ -1,2 +1,11 @@
 from .gptq import GPTQ
 from .quantizer import Quantizer, quantize
+from .nvfp4 import NVFP4Quantizer, quant_nvfp4
+
+__all__ = [
+    "GPTQ",
+    "Quantizer",
+    "quantize",
+    "NVFP4Quantizer",
+    "quant_nvfp4",
+]

--- a/auto_gptq/quantization/gptq.py
+++ b/auto_gptq/quantization/gptq.py
@@ -17,7 +17,7 @@ torch.backends.cudnn.allow_tf32 = False
 
 
 class GPTQ:
-    def __init__(self, layer):
+    def __init__(self, layer, quantizer: Quantizer | None = None):
         self.layer = layer
         self.dev = self.layer.weight.device
         W = layer.weight.data.clone()
@@ -29,7 +29,7 @@ class GPTQ:
         self.columns = W.shape[1]
         self.H = torch.zeros((self.columns, self.columns), device=self.dev)
         self.nsamples = 0
-        self.quantizer = Quantizer()
+        self.quantizer = quantizer if quantizer is not None else Quantizer()
 
     def add_batch(self, inp, out):
         if os.environ.get("DEBUG"):

--- a/auto_gptq/quantization/nvfp4.py
+++ b/auto_gptq/quantization/nvfp4.py
@@ -1,0 +1,83 @@
+import os
+import torch
+import torch.nn as nn
+from .quantizer import Quantizer
+
+FP8_E4M3_MAX = 448.0
+
+
+def fp4_121_positive(x: torch.Tensor, stochastic_rounding: bool = False) -> torch.Tensor:
+    if stochastic_rounding:
+        noise = torch.rand_like(x) - 0.5
+        step1 = torch.round(2.0 * x + noise) / 2.0
+        step2 = torch.round(x + noise)
+        step3 = 2.0 * torch.round(x / 2.0 + noise)
+    else:
+        step1 = torch.round(2.0 * x) / 2.0
+        step2 = torch.round(x)
+        step3 = 2.0 * torch.round(x / 2.0)
+
+    mask1 = x < 2.0
+    mask2 = x < 4.0
+
+    return step1 * mask1 + step2 * (~mask1) * mask2 + step3 * (~mask1) * (~mask2)
+
+
+def quant_nvfp4(
+    x: torch.Tensor,
+    stochastic_rounding: bool = False,
+    batch_size: int = 1,
+    vari_length: bool = False,
+) -> torch.Tensor:
+    quant_mode = os.environ.get("QUANT_MODE", "")
+    if quant_mode == "Dynamic_Double" and x.is_cuda:  # pragma: no cover
+        from .nvfp4_ext import nvfp4_forward  # type: ignore
+        x = nvfp4_forward(x, None, stochastic_rounding)
+        return x
+    fp4_121_max = 6.0
+    ori_shape = x.shape
+    x = x.reshape(-1, 16)
+    sign = x.sign()
+    x_abs = x.abs()
+    nvfp4_max = fp4_121_max * FP8_E4M3_MAX
+    scale_per_t = x_abs.max() / nvfp4_max
+    if quant_mode in ["Dynamic_Block", "Calib_Block"]:
+        scale_per_t = torch.tensor(1.0, device=x.device, dtype=x.dtype)
+    x_abs_scaled = x_abs / scale_per_t
+
+    if batch_size == 1:
+        scale_per_b = x_abs_scaled.max(dim=-1, keepdim=True)[0]
+    else:
+        scale_per_b = x_abs_scaled.max(dim=-1, keepdim=True)[0]
+
+    input_tensor = fp4_121_max / scale_per_b
+    down_cast = input_tensor.to(torch.float8_e4m3fn)
+    up_cast = down_cast.to(scale_per_b.dtype)
+    scale_per_b = torch.where(
+        (0 < up_cast) & (up_cast < torch.inf),
+        up_cast,
+        torch.tensor(1.0, device=scale_per_b.device, dtype=scale_per_b.dtype),
+    )
+
+    x_fp4_abs = fp4_121_positive(x_abs_scaled * scale_per_b, stochastic_rounding) / scale_per_b
+
+    return (sign * x_fp4_abs * scale_per_t).reshape(ori_shape)
+
+
+class NVFP4Quantizer(Quantizer):
+    """Stateless NVFP4 quantizer used for GPTQ."""
+
+    def __init__(self, shape=(1, 1)):
+        super().__init__(shape)
+
+    def configure(self, *args, **kwargs):  # pragma: no cover
+        return
+
+    def find_params(self, *args, **kwargs):  # pragma: no cover
+        return
+
+    def quantize(self, x: torch.Tensor) -> torch.Tensor:
+        return quant_nvfp4(x)
+
+
+__all__ = ["NVFP4Quantizer", "quant_nvfp4"]

--- a/lm_eval_gptq.py
+++ b/lm_eval_gptq.py
@@ -21,6 +21,7 @@ LM_EVAL_TASK_KWARGS_DICT = {
     # "rte": {"task": "rte", "num_fewshot": 0, "batch_size": 128, "metric": "acc"},
     "piqa": {"task": "piqa", "num_fewshot": 0, "batch_size": 128, "metric": "acc"},
     "mmlu": {"task": "mmlu", "num_fewshot": 5, "batch_size": 16, "metric": "acc"},
+    "gsm8k": {"task": "gsm8k", "num_fewshot": 5, "batch_size": 1, "metric": "exact_match"},
 }
 
 if __name__ == "__main__":
@@ -49,6 +50,12 @@ if __name__ == "__main__":
         "--proxy",
         action="store_true",
         help="Whether to skip MMLU",
+    )
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        default=None,
+        help="Comma separated list of tasks to evaluate, defaults to all",
     )
     args = parser.parse_args()
 
@@ -80,11 +87,16 @@ if __name__ == "__main__":
         with open(save_file_path, 'r') as file:
             all_metrics = json.load(file)
 
-    if args.proxy:
+    if args.proxy and "mmlu" in LM_EVAL_TASK_KWARGS_DICT:
         LM_EVAL_TASK_KWARGS_DICT.pop("mmlu")
         print("Skip MMLU for proxy benchmark as it is too large.")
 
-    for task_kwargs in LM_EVAL_TASK_KWARGS_DICT.values():
+    selected_tasks = (
+        args.tasks.split(",") if args.tasks else LM_EVAL_TASK_KWARGS_DICT.keys()
+    )
+
+    for name in selected_tasks:
+        task_kwargs = LM_EVAL_TASK_KWARGS_DICT[name]
         print(f"Evaluating task: {task_kwargs['task']}")
         task_name = task_kwargs["task"]
         lm = HFLM(

--- a/lm_eval_olmoe_nvfp4.sh
+++ b/lm_eval_olmoe_nvfp4.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Evaluate NVFP4 GPTQ-quantized OLMoE model on GSM8K with A4W4 settings
+MODEL_NAME=allenai/OLMoE-1B-7B-0924-Instruct
+QUANT_MODEL_PATH=autogptq_allenai/OLMoE-1B-7B-0924-Instruct-nvfp4
+
+# Use NVFP4 activation quantization
+echo "Evaluating $MODEL_NAME from $QUANT_MODEL_PATH on GSM8K"
+QUANT_MODE=Dynamic_Block CUDA_VISIBLE_DEVICES=0 python lm_eval_gptq.py \
+    --model_name $MODEL_NAME \
+    --quant_model_path $QUANT_MODEL_PATH \
+    --is_quantized \
+    --tasks gsm8k
+

--- a/quantize_gptq_olmoe.py
+++ b/quantize_gptq_olmoe.py
@@ -1,0 +1,98 @@
+import random
+from argparse import ArgumentParser
+
+import torch
+from datasets import load_dataset
+from transformers import AutoConfig, AutoTokenizer
+
+from auto_gptq import AutoGPTQForCausalLM_mixed_precision, BaseQuantizeConfig_mixed_precision
+from auto_gptq.modeling._utils import unpack_awq
+
+
+def get_wikitext2(tokenizer, seqlen: int, nsamples: int, split: str = "train"):
+    if split == "train":
+        data = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+    else:
+        data = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+    text = "".join([" \n" if s == "" else s for s in data["text"][:1000]])
+    enc = tokenizer(text, return_tensors="pt")
+    dataset = []
+    for _ in range(nsamples):
+        i = random.randint(0, enc.input_ids.shape[1] - seqlen - 1)
+        j = i + seqlen
+        inp = enc.input_ids[:, i:j]
+        attention_mask = torch.ones_like(inp)
+        dataset.append({"input_ids": inp, "attention_mask": attention_mask})
+    return dataset
+
+
+def build_bits_dict(config, attn_bits: int, expert_bits: int):
+    num_layers = getattr(config, "num_hidden_layers", getattr(config, "n_layers", 0))
+    num_experts = getattr(config, "num_local_experts", 8)
+    bits = {}
+    for layer in range(num_layers):
+        for proj in ["q_proj", "k_proj", "v_proj", "o_proj"]:
+            bits[f"model.layers.{layer}.self_attn.{proj}"] = attn_bits
+        for expert in range(num_experts):
+            for part in ["w1", "w2", "w3"]:
+                bits[f"model.layers.{layer}.block_sparse_moe.experts.{expert}.{part}"] = expert_bits
+    return bits
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--model_name", type=str, required=True)
+    parser.add_argument("--nsamples", type=int, default=512)
+    parser.add_argument("--group_size", type=int, default=128)
+    parser.add_argument("--attn_bits", type=int, default=4)
+    parser.add_argument("--expert_bits", type=int, default=4)
+    args = parser.parse_args()
+
+    config = AutoConfig.from_pretrained(args.model_name, trust_remote_code=True)
+    bits = build_bits_dict(config, args.attn_bits, args.expert_bits)
+    quantize_config = BaseQuantizeConfig_mixed_precision(
+        bits=bits,
+        group_size=args.group_size,
+        desc_act=False,
+        model_file_base_name=f"{args.model_name.split('/')[-1]}-nvfp4",
+        quant_type="nvfp4",
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name, trust_remote_code=True)
+    model = AutoGPTQForCausalLM_mixed_precision.from_pretrained(
+        args.model_name,
+        quantize_config,
+        torch_dtype=torch.float16,
+        trust_remote_code=True,
+        device_map="auto",
+    )
+    dataset = get_wikitext2(tokenizer, seqlen=4096, nsamples=args.nsamples)
+    model.quantize(dataset)
+    quant_path = f'autogptq_{args.model_name.split("/")[-1]}-nvfp4'
+    # Save GPTQ quantized checkpoint and dequantized weights for vanilla transformers
+    model.save_quantized(quant_path)
+
+    def _replace_quant_linear(module):
+        for name, child in list(module.named_children()):
+            if hasattr(child, "qweight"):
+                weight, _ = unpack_awq(
+                    child.qweight, child.qzeros, child.scales, bits=child.bits, group_size=child.group_size
+                )
+                new_linear = torch.nn.Linear(
+                    child.infeatures, child.outfeatures, bias=child.bias is not None, dtype=torch.float16
+                )
+                new_linear.weight.data.copy_(weight.t().to(torch.float16))
+                if child.bias is not None:
+                    new_linear.bias.data.copy_(child.bias.to(torch.float16))
+                setattr(module, name, new_linear)
+            else:
+                _replace_quant_linear(child)
+
+    _replace_quant_linear(model.model)
+    model.model.save_pretrained(quant_path, safe_serialization=True)
+    tokenizer.save_pretrained(quant_path)
+    print(f"Quantized model and weights saved to {quant_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- save NVFP4 GPTQ weights in HF format alongside quantization config
- dequantize quantized layers so vanilla transformers finds standard `weight` tensors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'awq_ext')*


------
https://chatgpt.com/codex/tasks/task_e_689b3cad15248332ada309a425127786